### PR TITLE
Update to dotnet 10 and latest action dependencies

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Changelog Entry
         id: get-changelog-entry
@@ -36,7 +36,7 @@ jobs:
           EOInfo
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         # only run if we have a changelog entry
         if: steps.get-changelog-entry.outputs.last-change-entry != ''
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # outdated-packages-action
 
+## 3.0.0
+
+### Major Changes
+
+- Change default dotnet version to 10.0.0
+- Update action dependencies to latest major versions (npm update check now uses node 20)
+
 ## 2.0.0
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This action will run either or both of:
 >
 > If the action is re-run against a pull request that has already been commented on, the existing comment will be updated. 
 >
-> `v1.7.0` and `v2.0.0` of this action are functionally identical, except `v1.7.0` defaults to using dotnet `8.*.*` and `v2.0.0` defaults to using dotnet `9.*.*`.
+> `v1.7.0`, `v2.0.0` and `v3.0.0` of this action are functionally identical, except `v1.7.0` defaults to using dotnet `8.*.*`, `v2.0.0` defaults to using dotnet `9.*.*` and `v3.0.0` defaults to using dotnet `10.*.*`.
+> `v3.0.0` also updates action dependencies to latest major versions (npm update check now uses node 20).
 
 > [!WARNING]
 > This action is designed to be actioned only within the context of a pull request, no other scenarios are catered for.
@@ -36,7 +37,7 @@ This action will run either or both of:
 
 #### `dotnet-version`
 
-**Optional** - The version of dotnet to use. Default `9.*.*`.
+**Optional** - The version of dotnet to use. Default `10.*.*`.
 
 #### `use-npm-outdated`
 
@@ -75,7 +76,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: trossr32/outdated-packages-action@v2.0.0
+      - uses: trossr32/outdated-packages-action@v3.0.0
         with:
           # Whether to run dotnet-outdated. Default is false if not supplied.
           use-dotnet-outdated: true
@@ -87,8 +88,8 @@ jobs:
           # Space delimited string of package names, e.g. "Microsoft.Extensions.Logging Microsoft.Extensions.Logging.Abstractions"
           dotnet-exclude-packages: ${{ env.EXCLUDE_PACKAGES }}
 
-          # The version of dotnet to use. Default is 9.*.*.
-          dotnet-version: '9.*.*'
+          # The version of dotnet to use. Default is 10.*.*.
+          dotnet-version: '10.*.*'
 
           # Whether to run npm-update-check-action. Default is false if not supplied.
           use-npm-outdated: true

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,11 @@ inputs:
     required: false
     default: ''
 
-  # dotnet version, defaults to 9.*.*
+  # dotnet version, defaults to 10.*.*
   dotnet-version:
     description: .NET version to use
     required: false
-    default: '9.*.*'
+    default: '10.*.*'
 
   # exclude nuget packages from the check
   dotnet-exclude-packages:
@@ -53,13 +53,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     # Validate action inputs
     - name: Validate action inputs
       shell: bash
       run: |
         echo "use-dotnet-outdated:              ${{ inputs.use-dotnet-outdated }}"
+        echo "dotnet-version:                   ${{ inputs.dotnet-version }}"
         echo "dotnet-solution-or-project-path:  ${{ inputs.dotnet-solution-or-project-path }}"
         echo "dotnet-exclude-packages:          ${{ inputs.dotnet-exclude-packages }}"
         echo "use-npm-outdated:                 ${{ inputs.use-npm-outdated }}"
@@ -88,7 +89,7 @@ runs:
 
     - name: NPM update check
       if: ${{ inputs.use-npm-outdated == 'true' }}
-      uses: MeilCli/npm-update-check-action@v4 
+      uses: MeilCli/npm-update-check-action@v5
       id: npm-outdated-check
       with:
         execute_directories: ${{ inputs.npm-project-directory }}
@@ -113,15 +114,15 @@ runs:
 
     - name: NPM outdated PR comment
       if: ${{ inputs.use-npm-outdated == 'true' && steps.npm-outdated.outputs.skip-comment == 'false' }}
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
-        filePath: "${{ inputs.npm-project-directory }}/npm_outdated.md"
-        comment_tag: npm_outdated
+        file-path: "${{ inputs.npm-project-directory }}/npm_outdated.md"
+        comment-tag: npm_outdated
 
     # Dotnet outdated
     - name: Restore packages
       if: ${{ inputs.use-dotnet-outdated == 'true' }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -183,7 +184,7 @@ runs:
 
     - name: Dotnet outdated PR comment
       if: ${{ inputs.use-dotnet-outdated == 'true' && steps.dotnet-outdated.outputs.skip-comment == 'false' }}
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
-        filePath: "outdated.md"
-        comment_tag: outdated
+        file-path: "outdated.md"
+        comment-tag: outdated


### PR DESCRIPTION
Bump default dotnet version to 10.*.* and update all GitHub Action dependencies to their latest major versions, including actions/checkout, softprops/action-gh-release, MeilCli/npm-update-check-action, thollander/actions-comment-pull-request, and actions/setup-dotnet. Update documentation and changelog to reflect these changes and ensure compatibility with node 20 for npm update checks.