### PR TITLE
Install dotnet-outdated locally and update action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # outdated-packages-action
 
+## 3.1.0
+
+### Minor Changes
+
+- Install dotnet-outdated-tool as a local tool instead of global to fix compatibility with ubuntu-slim runners
+
 ## 3.0.0
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This action will run either or both of:
 >
 > Reports for any outdated packages found are added as a comment to the pull request used to run this action.
 >
-> If the action is re-run against a pull request that has already been commented on, the existing comment will be updated. 
+> If the action is re-run against a pull request that has already been commented on, the existing comment will be updated.
 >
-> `v1.7.0`, `v2.0.0` and `v3.0.0` of this action are functionally identical, except `v1.7.0` defaults to using dotnet `8.*.*`, `v2.0.0` defaults to using dotnet `9.*.*` and `v3.0.0` defaults to using dotnet `10.*.*`.
-> `v3.0.0` also updates action dependencies to latest major versions (npm update check now uses node 20).
+> `v1.7.0`, `v2.0.0` and `v3.x.x` of this action are functionally identical, except `v1.7.0` defaults to using dotnet `8.*.*`, `v2.0.0` defaults to using dotnet `9.*.*` and `v3.x.x` defaults to using dotnet `10.*.*`.
+> `v3.x.x` also updates action dependencies to latest major versions (npm update check now uses node 20).
 
 > [!WARNING]
 > This action is designed to be actioned only within the context of a pull request, no other scenarios are catered for.

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     # Validate action inputs
     - name: Validate action inputs
@@ -134,7 +134,9 @@ runs:
     - name: Install dotnet outdated tool
       if: ${{ inputs.use-dotnet-outdated == 'true' }}
       shell: bash
-      run: dotnet tool install --global dotnet-outdated-tool
+      run: |
+        dotnet new tool-manifest --force
+        dotnet tool install dotnet-outdated-tool
 
     - name: Run outdated script
       if: ${{ inputs.use-dotnet-outdated == 'true' }}
@@ -155,7 +157,7 @@ runs:
             done
         fi
 
-        cmd="dotnet outdated ${{ inputs.dotnet-solution-or-project-path }} -of Markdown -o outdated.md -ifs $exclusions"
+        cmd="dotnet tool run dotnet-outdated ${{ inputs.dotnet-solution-or-project-path }} -of Markdown -o outdated.md -ifs $exclusions"
 
         echo $cmd
 


### PR DESCRIPTION
Switch actions/checkout to v6 and install dotnet-outdated-tool as a local .NET tool (using a tool manifest) instead of a global install to fix compatibility with ubuntu-slim runners. Update the command to run the tool via `dotnet tool run dotnet-outdated`. Also update README wording for v3.x.x and add a 3.1.0 changelog entry describing the minor change.